### PR TITLE
MySQLではサポートしていないid指定方法の修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
 
     @posts = Post
       .eager_load(:user, post_images: {image_attachment: :blob}, tags: :tag_group)
-      .where(id: post_ids)
+      .where(id: post_ids.map(&:id))
   end
 
   # GET /posts/1


### PR DESCRIPTION
ローカルと本番環境のDBが異なるため(Sqlite, Mysql)気づかなかった点を直しました。
そろそろテストコードも書いて、CI環境を用意したいですね..