### PR TITLE
キーワードやタグの組み合わせで投稿を検索することができる

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,16 +3,17 @@ class PostsController < ApplicationController
 
   # GET /posts
   def index
-    tag_ids = params[:tag_ids]&.split(",")
-    posts = Post.select(:id).joins(:tags)
-    posts = posts.where(tags: { id: tag_ids }) if tag_ids.present?
-    posts = posts.where(category_id: params[:category_id]) if params[:category_id].present?
-    posts = posts.where(sub_category_id: params[:sub_category_id]) if params[:sub_category_id].present?
-    post_ids = posts.page(params[:page]).per(params[:per])
+    tag_ids = params[:tag_ids]&.split(',')
+    condition_ids = params[:condition_ids]&.split(',')
+    posts = PostFinder.new(category_id: params[:category_id],
+                           sub_category_id: params[:sub_category_id],
+                           tag_ids: tag_ids,
+                           condition_ids: condition_ids).call
+    post_ids = posts.page(params[:page]).per(params[:per]).map(&:id)
 
     @posts = Post
       .eager_load(:user, post_images: {image_attachment: :blob}, tags: :tag_group)
-      .where(id: post_ids.map(&:id))
+      .where(id: post_ids)
   end
 
   # GET /posts/1

--- a/app/models/post_finder.rb
+++ b/app/models/post_finder.rb
@@ -1,0 +1,53 @@
+class PostFinder
+  def initialize(category_id:, sub_category_id:, tag_ids:, condition_ids:)
+    @category_id = category_id
+    @sub_category_id = sub_category_id
+    @tag_ids = tag_ids
+    @condition_ids = condition_ids
+  end
+
+  def call
+    posts = Post.select(:id).joins(:tags, :conditions)
+    posts = filter_by_category(posts, @category_id)
+    posts = filter_by_sub_category(posts, @sub_category_id)
+    filter_by_tags_and_conditions(posts, @tag_ids, @condition_ids)
+  end
+
+  private
+
+  def filter_by_category(posts, category_id)
+    return posts unless category_id.present?
+
+    posts.where(category_id: category_id) 
+  end
+
+  def filter_by_sub_category(posts, sub_category_id)
+    return posts unless sub_category_id.present?
+
+    posts.where(sub_category_id: sub_category_id) 
+  end
+
+  def filter_by_tags_and_conditions(posts, tag_ids, condition_ids)
+    return posts if tag_ids.blank? && condition_ids.blank?
+
+    posts = posts.group('posts.id')
+    posts = filter_by_tags(posts, tag_ids)
+    filter_by_conditions(posts, condition_ids)
+  end
+
+  def filter_by_tags(posts, tag_ids)
+    return posts unless tag_ids.present?
+
+    posts
+      .where(tags: { id: tag_ids })
+      .having('COUNT(DISTINCT tags.id) = ?', tag_ids.size)
+  end
+
+  def filter_by_conditions(posts, condition_ids)
+    return posts unless condition_ids.present?
+
+    posts
+      .where(conditions: { id: condition_ids })
+      .having('COUNT(DISTINCT conditions.id) = ?', condition_ids.size)
+  end
+end


### PR DESCRIPTION
## 作業内容
https://github.com/FA-MATE/fa-mate-rails/issues/11

検索の細かい要件はまだ決まってないですが、メジャーなサービスの検索機能と似た要件で仮実装しました。
これでカテゴリ、品種、複数のタグ、複数のお譲り条件の組み合わせで投稿が検索できます。

以下のような検索インタフェースを想定した実装になっているのでご参考ください。
![スクリーンショット 2024-03-07 16 11 46](https://github.com/FA-MATE/fa-mate-rails/assets/32471781/2702ac66-0989-4209-9c7a-473ff5e26509)
